### PR TITLE
Sentry error tracking

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,7 @@
                  [environ "1.0.0"]
                  [com.taoensso/carmine "2.13.1" :exclusions [org.clojure/clojure]]
                  [com.taoensso/timbre "4.3.1"]
+                 [raven-clj "1.5.0"]
                  [com.brweber2/clj-dns "0.0.2"]
                  [org.bovinegenius/exploding-fish "0.3.4"]
                  [com.cemerick/url "0.1.1"]

--- a/src/clj/shale/core.clj
+++ b/src/clj/shale/core.clj
@@ -56,7 +56,11 @@
    :proxy-pool (component/using (proxies/new-proxy-pool)
                                 [:config :redis-conn :logger])
    :app (component/using (handler/new-app)
-                         [:session-pool :node-pool :proxy-pool :logger])])
+                         [:config
+                          :session-pool
+                          :node-pool
+                          :proxy-pool
+                          :logger])])
 
 (defn get-app-system [conf]
   (keyvals->system (get-app-system-keyvals conf)))


### PR DESCRIPTION
Should make tracking down issues in production easier.

NB - I've started injecting config and other state into Ring requests to make our use of `component` closer to pure.