### PR TITLE
Delete node sessions

### DIFF
--- a/src/clj/shale/nodes.clj
+++ b/src/clj/shale/nodes.clj
@@ -132,6 +132,14 @@
                                           :tags tags
                                           :max-sessions max-sessions}))))))
 
+(s/defn ^:always-validate raw-sessions-with-node [pool    :- NodePool
+                                                  node-id :- s/Str]
+  (let [redis-conn (:redis-conn pool)]
+    (->> (redis/models redis-conn
+                       redis/SessionInRedis
+                       :include-soft-deleted? true)
+         (filter #(= node-id (:node-id %))))))
+
 (s/defn ^:always-validate destroy-node
   [pool :- NodePool
    id   :- s/Str]
@@ -187,14 +195,6 @@
     :not (s/recursive #'NodeRequirement)
     :and [(s/recursive #'NodeRequirement)]
     :or  [(s/recursive #'NodeRequirement)]))
-
-(s/defn ^:always-validate raw-sessions-with-node [pool    :- NodePool
-                                                  node-id :- s/Str]
-  (let [redis-conn (:redis-conn pool)]
-    (->> (redis/models redis-conn
-                       redis/SessionInRedis
-                       :include-soft-deleted? true)
-         (filter #(= node-id (:node-id %))))))
 
 (s/defn ^:always-validate raw-session-count [pool    :- NodePool
                                              node-id :- s/Str]

--- a/src/clj/shale/nodes.clj
+++ b/src/clj/shale/nodes.clj
@@ -75,11 +75,11 @@
        (merge {:id id})
        keywordize-keys))
 
-(s/defn view-model :- NodeView
+(s/defn view-model :- (s/maybe NodeView)
   "Given a node pool, get a view model from Redis."
   [pool :- NodePool
    id   :- s/Str]
-  (let [m (redis/model (:redis-conn pool) redis/NodeInRedis id)]
+  (when-let [m (redis/model (:redis-conn pool) redis/NodeInRedis id)]
     (->NodeView id m)))
 
 (s/defn view-models :- [NodeView]

--- a/src/clj/shale/nodes.clj
+++ b/src/clj/shale/nodes.clj
@@ -142,6 +142,8 @@
         (if (some #{url} (node-providers/get-nodes (:node-provider pool)))
           (node-providers/remove-node (:node-provider pool) url)))
       (finally
+        (doseq [session (raw-sessions-with-node pool id)]
+          (redis/delete-model! (:redis-conn pool) redis/SessionInRedis (:id session)))
         (redis/delete-model! (:redis-conn pool) redis/NodeInRedis id)
         (car/del (redis/node-tags-key id)))))
   true)

--- a/src/clj/shale/redis.clj
+++ b/src/clj/shale/redis.clj
@@ -233,7 +233,6 @@
                                        car/hgetall
                                        (wcar redis-conn)
                                        (apply hash-map))})]
-                (println "redis/models" model-schema id "=" sets lists maps)
                 (->> (concat sets lists maps)
                      (list* base)
                      (reduce merge)


### PR DESCRIPTION
- fix redis/model to return nil rather than throwing, when the model key isn't found. Previously it would try to coerce the non-existent model into the schema e.g. NodeInRedis
- fix several node fns to gracefully handle the node not being there
- when deleting a node, also delete its associated sessions
- use `when` rather than `if` in several places. 